### PR TITLE
fix(ci): guard docs build when previous commit lacks mkdocs.yml

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -79,7 +79,15 @@ jobs:
       - name: Build docs at previous commit
         run: |
           git checkout HEAD^
-          uv run mkdocs build --site-dir generated/mkdocs/previous
+          if [ -f mkdocs.yml ]; then
+            uv run mkdocs build --site-dir generated/mkdocs/previous
+          else
+            # No mkdocs.yml at the previous commit (e.g. the commit that first
+            # introduced the docs). Leave "previous" empty so the diff below
+            # treats every page as new and publishes.
+            echo "No mkdocs.yml at previous commit — skipping previous build"
+            mkdir -p generated/mkdocs/previous
+          fi
 
       - name: Build docs at last main commit
         run: |


### PR DESCRIPTION
## Summary

The `publish_docs.yml` workflow's **"Build docs at previous commit"** step checks out `HEAD^` and runs `mkdocs build`. When the previous commit predates the docs (as with the commit that first introduced MkDocs, #327), there is no `mkdocs.yml` there and the build fails with `Error: Config file 'mkdocs.yml' does not exist.` — see [failed run](https://github.com/looztra/kubesplit/actions/runs/28737202015/job/85213420560).

## Changes

- Guard the previous-commit build: only run `mkdocs build` if `mkdocs.yml` exists at `HEAD^`.
- Otherwise leave the `previous` site dir empty so the existing `diff -r` step treats every page as new and publishes.

## Test plan

- The workflow runs on push to `main`. Once merged, the "previous commit" (`469f766`) now contains `mkdocs.yml`, so the run passes normally.
- The guard makes the first-run bootstrap case durable against recurrence.