### PR TITLE
ci(workflows): harden workflows with zizmor, add CodeQL and mise tasks

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -18,6 +18,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-checks
   cancel-in-progress: true
@@ -41,7 +44,7 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
@@ -97,7 +100,7 @@ jobs:
       - name: Run pre-commit checks
         run: |
           echo "::group::Run pre-commit checks"
-          pre-commit run --all-files --show-diff-on-failure
+          mise run precommit:run
           echo "::endgroup::"
 
   python-checks:
@@ -105,22 +108,36 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       deploy_env: ${{ steps.detect-deploy-env.outputs.deploy_env }}
+      is_release: ${{ steps.detect-release.outputs.is_release }}
     needs:
       - pre-commit
     steps:
+      - name: Detect release run
+        id: detect-release
+        env:
+          IS_RELEASE: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main') || inputs.force_release) && 'true' || 'false' }}
+        run: |
+          echo "is_release=${IS_RELEASE}" >> "${GITHUB_OUTPUT}"
+
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Full history is required: versioningit computes the version
+          # of the built distribution from git tags and commit distance.
           fetch-depth: 0
+          persist-credentials: false
 
+      # Caches are disabled on release runs so that a poisoned cache entry
+      # cannot influence the distribution published to (Test)PyPI.
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install: true
-          cache: ${{ vars.MISE_CACHE_ENABLED || 'true'}}
+          cache: ${{ steps.detect-release.outputs.is_release == 'true' && 'false' || vars.MISE_CACHE_ENABLED || 'true' }}
           cache_key_prefix: ${{ vars.MISE_CACHE_KEY_PREFIX || 'mise-v0'}}
           version: ${{ vars.MISE_VERSION }}
 
       - name: Restore uv cache
+        if: steps.detect-release.outputs.is_release != 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/.uv-cache
@@ -132,15 +149,15 @@ jobs:
       - name: Setup venv
         run: |
           uv python install
-          make setup-venv
+          mise run venv:setup
 
       - name: Python checks
         run: |
-          echo "::group::make lint"
-          make lint
+          echo "::group::mise run lint"
+          mise run lint
           echo "::endgroup::"
-          echo "::group::make test"
-          make test
+          echo "::group::mise run test"
+          mise run test
           echo "::endgroup::"
 
       - name: Upload test results to Codecov
@@ -148,8 +165,8 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: generated/junit.xml
-          report-type: test_results
+          files: generated/junit.xml
+          report_type: test_results
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -158,8 +175,8 @@ jobs:
 
       - name: Run Integration tests
         run: |
-          echo "::group::make integration-tests"
-          make integration-tests
+          echo "::group::mise run test:integration"
+          mise run test:integration
           echo "::endgroup::"
 
       - name: Minimize uv cache
@@ -167,19 +184,19 @@ jobs:
 
       - name: Check we can build the distribution
         run: |
-          echo "::group::make dist"
-          make dist
+          echo "::group::mise run dist"
+          mise run dist
           echo "::endgroup::"
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main') || inputs.force_release
+        if: steps.detect-release.outputs.is_release == 'true'
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Detect environment
-        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main') || inputs.force_release
+        if: steps.detect-release.outputs.is_release == 'true'
         id: detect-deploy-env
         run: |
           echo "deploy_env=${{ startsWith(github.ref, 'refs/tags') && 'pypi' || 'testpypi' }}" >> "${GITHUB_OUTPUT}"
@@ -187,7 +204,7 @@ jobs:
   deploy-release:
     name: Deploy Release
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main') || inputs.force_release
+    if: needs.python-checks.outputs.is_release == 'true'
     environment:
       name: ${{ needs.python-checks.outputs.deploy_env }}
       url: ${{ needs.python-checks.outputs.deploy_env == 'pypi' && 'https://pypi.org/project/kubesplit/' || 'https://test.pypi.org/project/kubesplit/' }}
@@ -203,6 +220,6 @@ jobs:
           path: dist/
 
       - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # unstable/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: ${{ needs.python-checks.outputs.deploy_env == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+---
+name: CodeQL
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: 43 7 * * 1
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # required to upload CodeQL results
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - python
+
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/lint_pr_titles.yml
+++ b/.github/workflows/lint_pr_titles.yml
@@ -2,11 +2,17 @@
 name: Lint PR Title
 
 on:
-  pull_request_target:
+  # pull_request_target is required to comment on PRs coming from forks.
+  # It is safe here: the workflow never checks out or executes PR code,
+  # and the token is restricted to pull-requests: write below.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - opened
       - edited
       - synchronize
+
+permissions:
+  pull-requests: write
 
 jobs:
   lint-pr-title:
@@ -19,7 +25,7 @@ jobs:
         with:
           requireScope: true
 
-      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -35,7 +41,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -37,7 +37,12 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Full history is required: this job checks out HEAD^ and main to
+          # diff the docs builds, and the git-revision-date-localized mkdocs
+          # plugin needs the commit history to render accurate page dates.
           fetch-depth: 0
+          # Credentials must be persisted: `mkdocs gh-deploy` pushes to gh-pages.
+          persist-credentials: true # zizmor: ignore[artipacked]
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:

--- a/.github/workflows/workflows_checks.yml
+++ b/.github/workflows/workflows_checks.yml
@@ -10,17 +10,31 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   repo-checks:
     name: Check the repository github actions workflows
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write # required by reviewdog's github-check reporter
 
     steps:
       - name: Checkout current branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Run actionlint
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           fail_level: error
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false
+          annotations: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+---
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+rules:
+  cache-poisoning:
+    # code_checks.yml publishes release artifacts to (Test)PyPI, which makes
+    # zizmor flag every cache-enabled job in it. The only job on the release
+    # path (python-checks, which builds the published dist/) disables all
+    # caches on release runs; the caches of the other jobs cannot reach the
+    # published artifacts.
+    ignore:
+      - code_checks.yml

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,11 @@
 [tools]
+actionlint = "1.7"
 editorconfig-checker = "3"
 "pipx:pre-commit" = { version = "4.6.0", uvx_args = "--with pre-commit-uv" }
 shellcheck = "0.11"
 shfmt = "3"
 uv = "0.11.28"
+zizmor = "1.26"
 
 [settings]
 idiomatic_version_file_enable_tools = [
@@ -11,5 +13,6 @@ idiomatic_version_file_enable_tools = [
 
 [task_config]
 includes = [
+    "toolbox/mise/tasks/toml/*.toml",
     "toolbox/scripts",
 ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
     rev: v1.1.0
     hooks:
       - id: yamkix
-        args: [--no-quotes-preserved]
+        args: [--no-quotes-preserved, --silent]
         exclude: |
           (?x)^(
               test-assets/.*|

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -15,8 +15,13 @@ pyright = [
 ]
 "pyright:run" = "pyright"
 "pytest:cov" = "pytest --cov src --cov-report=xml --cov-report=term-missing --cov-branch --junitxml=generated/junit.xml -o junit_family=legacy"
+"ruff:fmt" = "ruff format"
 "ruff:fmt:check" = "ruff format --check"
-"ruff:fmt:run" = "ruff format"
+"ruff:fmt:run" = [
+    "ruff:isort",
+    "ruff:fmt",
+]
+"ruff:isort" = "ruff check --select I --fix"
 "ruff:lint" = "ruff check"
 "ruff:lint:fix" = "ruff check --fix"
 style = [

--- a/renovate.json5
+++ b/renovate.json5
@@ -12,4 +12,16 @@
     enabled: true,
     automerge: true
   },
+  packageRules: [
+    {
+      matchManagers: [
+        "pep621",
+        "pip_requirements",
+        "uv",
+        "github-actions",
+        "pre-commit"
+      ],
+      minimumReleaseAge: "7 days"
+    }
+  ],
 }

--- a/toolbox/mise/tasks/toml/build.toml
+++ b/toolbox/mise/tasks/toml/build.toml
@@ -1,0 +1,3 @@
+[dist]
+description = "Build the python wheel(s) (same as 'make dist')"
+run = "uv build --wheel --all"

--- a/toolbox/mise/tasks/toml/checks.toml
+++ b/toolbox/mise/tasks/toml/checks.toml
@@ -1,0 +1,7 @@
+["check:actionlint"]
+description = "Lint the GitHub Actions workflows with actionlint"
+run = "actionlint"
+
+["check:zizmor"]
+description = "Audit the GitHub Actions workflows with zizmor"
+run = "zizmor .github/"

--- a/toolbox/mise/tasks/toml/docs.toml
+++ b/toolbox/mise/tasks/toml/docs.toml
@@ -1,0 +1,7 @@
+["docs:build"]
+description = "Build the documentation (same as 'make build-docs')"
+run = "uv run mkdocs build --site-dir generated/mkdocs/HEAD"
+
+["docs:serve"]
+description = "Serve the documentation locally (same as 'make serve-docs')"
+run = "uv run mkdocs serve"

--- a/toolbox/mise/tasks/toml/lint.toml
+++ b/toolbox/mise/tasks/toml/lint.toml
@@ -1,0 +1,11 @@
+[lint]
+description = "Run all linters (ruff, ty, pylint, pyright) via poe (same as 'make lint')"
+run = "uv run --frozen poe lint:all"
+
+["lint:fast"]
+description = "Run ruff check only (same as 'make fast-lint')"
+run = "uv run --frozen ruff check"
+
+[style]
+description = "Run all formatters via poe (same as 'make style')"
+run = "uv run --frozen poe style"

--- a/toolbox/mise/tasks/toml/precommit.toml
+++ b/toolbox/mise/tasks/toml/precommit.toml
@@ -1,0 +1,7 @@
+["precommit:install"]
+description = "Install the pre-commit hooks (same as 'make precommit-install')"
+run = "pre-commit install"
+
+["precommit:run"]
+description = "Run the pre-commit hooks on all files (same as 'make precommit-run')"
+run = "pre-commit run --show-diff-on-failure --color=always --all-files"

--- a/toolbox/mise/tasks/toml/test.toml
+++ b/toolbox/mise/tasks/toml/test.toml
@@ -1,0 +1,25 @@
+[test]
+description = "Run tests with coverage via poe (same as 'make test')"
+run = "uv run --frozen poe pytest:cov"
+
+["test:fast"]
+description = "Run unit tests quickly, no coverage, integration tests excluded"
+run = "uv run --frozen pytest -m 'not integration'"
+
+["test:integration"]
+description = "Run integration tests (same as 'make integration-tests')"
+run = "uv run --frozen pytest -m integration"
+
+["test:python-versions"]
+description = "Run tests for all supported python versions with tox"
+run = "uv run tox run"
+
+["test:all"]
+# Sequential on purpose: the suites share generated/ artifacts and tox
+# rebuilds environments, so they must not run concurrently.
+description = "Run all test suites"
+run = [
+    "mise run test",
+    "mise run test:integration",
+    "mise run test:python-versions",
+]

--- a/toolbox/mise/tasks/toml/venv.toml
+++ b/toolbox/mise/tasks/toml/venv.toml
@@ -1,0 +1,18 @@
+["venv:setup"]
+description = "Setup the virtual env (same as 'make setup-venv')"
+run = "uv sync --frozen --all-packages --keyring-provider subprocess"
+
+["venv:lock"]
+description = "Refresh the lock file (same as 'make generate-lock-file')"
+run = "uv lock --keyring-provider subprocess"
+
+["venv:upgrade"]
+description = "Upgrade dependencies in uv.lock and the venv (same as 'make upgrade-dependencies')"
+run = "uv sync --upgrade --all-packages --keyring-provider subprocess"
+
+["venv:recreate"]
+description = "Delete and recreate the virtual env (same as 'make recreate-venv')"
+run = [
+    "rm -rf .venv",
+    "uv sync --frozen --all-packages --keyring-provider subprocess",
+]


### PR DESCRIPTION
## Summary

Replicates the CI hardening done in yamkix (looztra/yamkix#448 and looztra/yamkix#449): zizmor static analysis, tightened token permissions, cache-poisoning protection on the release path, pinned actions, CodeQL code scanning, and mise tasks mirroring the make targets.

## Changes

- **workflows_checks.yml**: run zizmor (via `zizmorcore/zizmor-action`) alongside actionlint; explicit `contents: read` / `checks: write` permissions
- **code_checks.yml**: top-level `contents: read` permission and `persist-credentials: false` on all checkouts; dedicated `detect-release` step reused by downstream conditions; mise and uv caches disabled on release runs so a poisoned cache cannot reach the (Test)PyPI distribution; pin `pypa/gh-action-pypi-publish` to v1.14.0 (was an unstable ref); fix deprecated codecov params (`files` / `report_type`); switch steps from `make` to `mise run` tasks
- **lint_pr_titles.yml**: scope token to `pull-requests: write`, document why `pull_request_target` is safe here (zizmor ignore), pin sticky-comment action to v3.0.5
- **publish_docs.yml**: keep `persist-credentials: true` explicitly with justification (`mkdocs gh-deploy` pushes to gh-pages)
- **zizmor.yml**: new config ignoring `cache-poisoning` in code_checks.yml, with rationale
- **codeql.yml**: new workflow scanning `python` and `actions` with `build-mode: none`, weekly schedule, minimal permissions and pinned SHAs
- **toolbox/mise/tasks/toml/**: mise tasks (lint, test, dist, docs, venv, precommit, checks) mirroring the make targets; `actionlint` and `zizmor` added to `.mise.toml` tools
- **poe_tasks.toml**: split `ruff:fmt:run` into `ruff:isort` + `ruff:fmt`
- **.pre-commit-config.yaml**: add `--silent` to the yamkix hook

## Verification

- `zizmor` v1.26.1: no findings across all six workflows; `actionlint` clean
- All 19 mise tasks register; `venv:setup`, `lint:fast`, `style` and two full `precommit:run` passes exercised locally (no diffs produced)
- The workflows in this PR validate themselves via actionlint + zizmor on this very run

## Note

If the GitHub repo has *default* CodeQL setup enabled, it must be switched off (Settings → Code security) before the advanced workflow can upload results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)