### PR TITLE
fix(pre-commit): drop stray .git suffix from yamllint repo url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: shfmt # Check shell style with shfmt
         exclude: ^shared/bats-libs/.*
 
-  - repo: https://github.com/adrienverge/yamllint.git
+  - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:
       - id: yamllint


### PR DESCRIPTION
## Description

Zizmor 1.30.0 (pulled in via the `zizmorcore/zizmor-action` v0.6.2 -> v0.6.3 bump in #397) extends the `ref-confusion` audit to also cover `.pre-commit-config.yaml`. It resolves each `repo:` URL to a GitHub `owner/repo` path and calls the GitHub API to list branches.

The `adrienverge/yamllint` entry in `.pre-commit-config.yaml` was the only `repo:` in the file with a trailing `.git` suffix. Zizmor includes that suffix literally in the API path (`GET /repos/adrienverge/yamllint.git/branches` -> `404 Not Found`), which it maps to `can't access adrienverge/yamllint.git: missing or you have no access` and treats as fatal — breaking the `Check the repository github actions workflows` CI job (confirmed failing on #397).

This is **not** a `GITHUB_TOKEN` scope/permissions issue: `adrienverge/yamllint` is public, and the failure reproduces identically running zizmor 1.30.0 locally, anonymously, against this repo. Dropping the stray `.git` suffix — matching every other `repo:` entry in this file — fixes it.

Same issue, same fix, previously applied in looztra/yamkix#517.

## Type of change

- [x] Bug fix

## How has this been tested?

- `uv run poe test` passes (77 passed)
- `make integration-tests` passes (11 passed)
- `uv run poe lint:all` passes (ruff, ty, pylint, pyright)
- `uv run pre-commit run --all-files` passes
- Verified with the actual failing tool, zizmor v1.30.0 (matching the pinned CI image):
  - Before fix: `zizmor .` -> `fatal: no audit was performed` / `couldn't list branches for adrienverge/yamllint.git` / `can't access adrienverge/yamllint.git: missing or you have no access`.
  - After fix: `zizmor .` -> `No findings to report. Good job! (6 ignored, 18 suppressed)`.
  - `uv run pre-commit run yamllint --all-files` -> hook still resolves/clones `adrienverge/yamllint` and passes, confirming the URL change doesn't break pre-commit itself.